### PR TITLE
Exclude preview.png from git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,4 +21,5 @@
 *.dll filter=lfs diff=lfs merge=lfs -text
 Docs/Images/*.png -filter -diff -merge
 Docs/Images/*.gif -filter -diff -merge
+preview.png -filter -diff -merge
 


### PR DESCRIPTION
`preview.png` image file was added before setting up git LFS. Hence, it is flagged as modified after cloning the repo.

It is added to the ignore list in LFS in this PR, as it should be accessible from github as a part of the documentation.